### PR TITLE
consolidate reader/processor/writer configuration.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ codenarc {
 mainClassName = 'org.springframework.batch.core.launch.support.CommandLineJobRunner'
 
 run {
-  args 'config.xml', 'StopJob'
+  args 'config.xml', 'gtfsJob'
 }
 
 test {

--- a/src/main/resources/agency-config.xml
+++ b/src/main/resources/agency-config.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:batch="http://www.springframework.org/schema/batch"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/batch
+    http://www.springframework.org/schema/batch/spring-batch.xsd
+    http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+
+    <bean id="agency" class="transitdata.io.domain.Agency" scope="prototype"/>
+
+    <bean id="lineTokenizer" class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
+        <property name="strict" value="false"/>
+    </bean>
+
+    <bean id="agencyHeaderHandler" class="transitdata.io.batch.HeaderHandler"/>
+
+    <bean id="agencyItemReader"
+          class="org.springframework.batch.item.file.FlatFileItemReader">
+        <!-- Read a csv file -->
+        <property name="resource" value="classpath:gtfs/agency.txt"/>
+
+        <property name="linesToSkip" value="1"/>
+        <property name="skippedLinesCallback" ref="agencyHeaderHandler"/>
+
+        <property name="lineMapper">
+            <bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
+                <!-- split it -->
+                <property name="lineTokenizer" ref="lineTokenizer"/>
+
+                <!-- map to an object -->
+                <property name="fieldSetMapper">
+                    <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
+                        <property name="prototypeBeanName" value="agency"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <bean id="agencyItemWriter" class="org.springframework.batch.item.database.JdbcBatchItemWriter">
+        <property name="dataSource" ref="dataSource"/>
+        <property name="sql">
+            <value>
+                <![CDATA[
+                    INSERT INTO AGENCY(
+                    agency_id, transit_system,agency_name,agency_url,agency_timezone,agency_lang
+                    )
+                    VALUES(
+                     :agency_id,'METRO_TRANSIT',:agency_name,:agency_url,:agency_timezone,:agency_lang
+                    );
+                ]]>
+            </value>
+        </property>
+        <property name="itemSqlParameterSourceProvider">
+            <bean class="org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider"/>
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/calendar-config.xml
+++ b/src/main/resources/calendar-config.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:batch="http://www.springframework.org/schema/batch"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/batch
+    http://www.springframework.org/schema/batch/spring-batch.xsd
+    http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+
+    <bean id="calendar" class="transitdata.io.domain.Calendar" scope="prototype"/>
+
+    <bean id="lineTokenizer" class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
+        <property name="strict" value="false"/>
+    </bean>
+
+    <bean id="calendarHeaderHandler" class="transitdata.io.batch.HeaderHandler"/>
+
+    <bean id="calendarItemReader"
+          class="org.springframework.batch.item.file.FlatFileItemReader">
+        <!-- Read a csv file -->
+        <property name="resource" value="classpath:gtfs/calendar.txt"/>
+
+        <property name="linesToSkip" value="1"/>
+        <property name="skippedLinesCallback" ref="calendarHeaderHandler"/>
+
+        <property name="lineMapper">
+            <bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
+                <!-- split it -->
+                <property name="lineTokenizer" ref="lineTokenizer"/>
+
+                <!-- map to an object -->
+                <property name="fieldSetMapper">
+                    <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
+                        <property name="prototypeBeanName" value="calendar"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <bean id="calendarItemWriter" class="org.springframework.batch.item.database.JdbcBatchItemWriter">
+        <property name="dataSource" ref="dataSource"/>
+        <property name="sql">
+            <value>
+                <![CDATA[
+                    INSERT INTO CALENDAR(
+                    service_id,transit_system,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+                    )
+                    VALUES(
+                     :service_id,'METRO_TRANSIT',:monday,:tuesday,:wednesday,:thursday,:friday,:saturday,:sunday,:start_date,:end_date
+                    );
+                ]]>
+            </value>
+        </property>
+        <property name="itemSqlParameterSourceProvider">
+            <bean class="org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider"/>
+        </property>
+    </bean>
+
+</beans>

--- a/src/main/resources/config.xml
+++ b/src/main/resources/config.xml
@@ -12,6 +12,10 @@
 
     <context:component-scan base-package="transitdata.io.domain"/>
 
+    <import resource="agency-config.xml"/>
+    <import resource="stop-config.xml"/>
+    <import resource="calendar-config.xml"/>
+
     <!--Load our properties file-->
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="location" value="batch.properties"/>
@@ -49,48 +53,27 @@
         <property name="jobRepository" ref="jobRepository"/>
     </bean>
 
-    <bean id="stop" class="transitdata.io.domain.Stop" scope="prototype"/>
-
-    <bean id="stopItemReader"
-          class="org.springframework.batch.item.file.FlatFileItemReader">
-        <!-- Read a csv file -->
-        <property name="resource" value="classpath:gtfs/stops.txt"/>
-
-        <property name="lineMapper">
-            <bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
-                <!-- split it -->
-                <property name="lineTokenizer">
-                    <bean class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
-                        <property name="names"
-                                  value="id,name,desc,lat,lon,street,city,region,postcode,country,zoneid,wheelchairboarding,url"/>
-                    </bean>
-                </property>
-                <property name="fieldSetMapper">
-                    <!-- map to an object -->
-                    <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
-                        <property name="prototypeBeanName" value="stop"/>
-                    </bean>
-                </property>
-
-            </bean>
-        </property>
-    </bean>
-
-    <bean id="stopItemWriter" class="org.springframework.batch.item.database.JdbcBatchItemWriter">
-        <property name="dataSource" ref="dataSource"/>
-        <property name="sql">
-            <value><![CDATA[INSERT INTO STOP VALUES(:id);]]></value>
-        </property>
-        <property name="itemSqlParameterSourceProvider">
-            <bean class="org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider"/>
-        </property>
-    </bean>
-
-    <batch:job id="StopJob" restartable="false" job-repository="jobRepository">
-        <batch:step id="step1">
+    <batch:job id="gtfsJob" restartable="false" job-repository="jobRepository">
+        <batch:step id="stopStep" next="agencyStep">
             <tasklet>
                 <chunk reader="stopItemReader"
                        writer="stopItemWriter"
+                       commit-interval="10000"/>
+                <!--TODO Set appropriate commit-interval value-->
+            </tasklet>
+        </batch:step>
+        <batch:step id="agencyStep" next="calendarStep">
+            <tasklet>
+                <chunk reader="agencyItemReader"
+                       writer="agencyItemWriter"
+                       commit-interval="10000"/>
+                <!--TODO Set appropriate commit-interval value-->
+            </tasklet>
+        </batch:step>
+        <batch:step id="calendarStep">
+            <tasklet>
+                <chunk reader="calendarItemReader"
+                       writer="calendarItemWriter"
                        commit-interval="10000"/>
                 <!--TODO Set appropriate commit-interval value-->
             </tasklet>

--- a/src/main/resources/stop-config.xml
+++ b/src/main/resources/stop-config.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:batch="http://www.springframework.org/schema/batch"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/batch
+    http://www.springframework.org/schema/batch/spring-batch.xsd
+    http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <bean id="stop" class="transitdata.io.domain.Stop" scope="prototype"/>
+
+    <bean id="lineTokenizer" class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
+        <property name="strict" value="false"/>
+    </bean>
+
+    <bean id="stopsHeaderHandler" class="transitdata.io.batch.HeaderHandler"/>
+
+    <bean id="stopItemReader"
+          class="org.springframework.batch.item.file.FlatFileItemReader">
+        <!-- Read a csv file -->
+        <property name="resource" value="classpath:gtfs/stops.txt"/>
+
+        <property name="linesToSkip" value="1"/>
+        <property name="skippedLinesCallback" ref="stopsHeaderHandler"/>
+
+        <property name="lineMapper">
+            <bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
+                <!-- split it -->
+                <property name="lineTokenizer" ref="lineTokenizer"/>
+
+                <!-- map to an object -->
+                <property name="fieldSetMapper">
+                    <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
+                        <property name="prototypeBeanName" value="stop"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <bean id="stopItemWriter" class="org.springframework.batch.item.database.JdbcBatchItemWriter">
+        <property name="dataSource" ref="dataSource"/>
+        <property name="sql">
+            <value>
+                <![CDATA[
+                    INSERT INTO STOP(transit_system,stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,
+                    stop_street,stop_city,stop_region,stop_postcode,stop_country,zone_id,stop_url,location_type,
+                    parent_station,stop_timezone,wheelchair_boarding)
+                     VALUES(
+                     'METRO_TRANSIT', :stop_id, :stop_code, :stop_name, :stop_desc,
+                     :stop_lat, :stop_lon, :stop_street, :stop_city, :stop_region,
+                     :stop_postcode,:stop_country, :zone_id, :stop_url,
+                     :location_type, :parent_station, :stop_timezone, :wheelchair_boarding
+                    );
+                ]]>
+            </value>
+        </property>
+        <property name="itemSqlParameterSourceProvider">
+            <bean class="org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider"/>
+        </property>
+    </bean>
+
+</beans>

--- a/src/test/resources/jobs/agency-job.xml
+++ b/src/test/resources/jobs/agency-job.xml
@@ -8,56 +8,7 @@
     http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <import resource="../test-config.xml"/>
-
-    <bean id="agency" class="transitdata.io.domain.Agency" scope="prototype"/>
-
-    <bean id="lineTokenizer" class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
-        <property name="strict" value="false"/>
-    </bean>
-
-    <bean id="agencyHeaderHandler" class="transitdata.io.batch.HeaderHandler"/>
-
-    <bean id="agencyItemReader"
-          class="org.springframework.batch.item.file.FlatFileItemReader">
-        <!-- Read a csv file -->
-        <property name="resource" value="classpath:gtfs/agency.txt"/>
-
-        <property name="linesToSkip" value="1"/>
-        <property name="skippedLinesCallback" ref="agencyHeaderHandler"/>
-
-        <property name="lineMapper">
-            <bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
-                <!-- split it -->
-                <property name="lineTokenizer" ref="lineTokenizer"/>
-
-                <!-- map to an object -->
-                <property name="fieldSetMapper">
-                    <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
-                        <property name="prototypeBeanName" value="agency"/>
-                    </bean>
-                </property>
-            </bean>
-        </property>
-    </bean>
-
-    <bean id="agencyItemWriter" class="org.springframework.batch.item.database.JdbcBatchItemWriter">
-        <property name="dataSource" ref="dataSource"/>
-        <property name="sql">
-            <value>
-                <![CDATA[
-                    INSERT INTO AGENCY(
-                    agency_id, transit_system,agency_name,agency_url,agency_timezone,agency_lang
-                    )
-                    VALUES(
-                     :agency_id,'METRO_TRANSIT',:agency_name,:agency_url,:agency_timezone,:agency_lang
-                    );
-                ]]>
-            </value>
-        </property>
-        <property name="itemSqlParameterSourceProvider">
-            <bean class="org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider"/>
-        </property>
-    </bean>
+    <import resource="../../main/agency-config.xml"/>
 
     <batch:job id="AgencyJob" restartable="false" job-repository="jobRepository">
         <batch:step id="step1">

--- a/src/test/resources/jobs/calendar-job.xml
+++ b/src/test/resources/jobs/calendar-job.xml
@@ -8,56 +8,7 @@
     http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <import resource="../test-config.xml"/>
-
-    <bean id="calendar" class="transitdata.io.domain.Calendar" scope="prototype"/>
-
-    <bean id="lineTokenizer" class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
-        <property name="strict" value="false"/>
-    </bean>
-
-    <bean id="calendarHeaderHandler" class="transitdata.io.batch.HeaderHandler"/>
-
-    <bean id="calendarItemReader"
-          class="org.springframework.batch.item.file.FlatFileItemReader">
-        <!-- Read a csv file -->
-        <property name="resource" value="classpath:gtfs/calendar.txt"/>
-
-        <property name="linesToSkip" value="1"/>
-        <property name="skippedLinesCallback" ref="calendarHeaderHandler"/>
-
-        <property name="lineMapper">
-            <bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
-                <!-- split it -->
-                <property name="lineTokenizer" ref="lineTokenizer"/>
-
-                <!-- map to an object -->
-                <property name="fieldSetMapper">
-                    <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
-                        <property name="prototypeBeanName" value="calendar"/>
-                    </bean>
-                </property>
-            </bean>
-        </property>
-    </bean>
-
-    <bean id="calendarItemWriter" class="org.springframework.batch.item.database.JdbcBatchItemWriter">
-        <property name="dataSource" ref="dataSource"/>
-        <property name="sql">
-            <value>
-                <![CDATA[
-                    INSERT INTO CALENDAR(
-                    service_id,transit_system,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
-                    )
-                    VALUES(
-                     :service_id,'METRO_TRANSIT',:monday,:tuesday,:wednesday,:thursday,:friday,:saturday,:sunday,:start_date,:end_date
-                    );
-                ]]>
-            </value>
-        </property>
-        <property name="itemSqlParameterSourceProvider">
-            <bean class="org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider"/>
-        </property>
-    </bean>
+    <import resource="../../main/calendar-config.xml"/>
 
     <batch:job id="CalendarJob" restartable="false" job-repository="jobRepository">
         <batch:step id="step1">

--- a/src/test/resources/jobs/stops-job.xml
+++ b/src/test/resources/jobs/stops-job.xml
@@ -8,59 +8,7 @@
     http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <import resource="../test-config.xml"/>
-
-    <bean id="stop" class="transitdata.io.domain.Stop" scope="prototype"/>
-
-    <bean id="lineTokenizer" class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
-        <property name="strict" value="false"/>
-    </bean>
-
-    <bean id="stopsHeaderHandler" class="transitdata.io.batch.HeaderHandler"/>
-
-    <bean id="stopItemReader"
-          class="org.springframework.batch.item.file.FlatFileItemReader">
-        <!-- Read a csv file -->
-        <property name="resource" value="classpath:gtfs/stops.txt"/>
-
-        <property name="linesToSkip" value="1"/>
-        <property name="skippedLinesCallback" ref="stopsHeaderHandler"/>
-
-        <property name="lineMapper">
-            <bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
-                <!-- split it -->
-                <property name="lineTokenizer" ref="lineTokenizer"/>
-
-                <!-- map to an object -->
-                <property name="fieldSetMapper">
-                    <bean class="org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper">
-                        <property name="prototypeBeanName" value="stop"/>
-                    </bean>
-                </property>
-            </bean>
-        </property>
-    </bean>
-
-    <bean id="stopItemWriter" class="org.springframework.batch.item.database.JdbcBatchItemWriter">
-        <property name="dataSource" ref="dataSource"/>
-        <property name="sql">
-            <value>
-                <![CDATA[
-                    INSERT INTO STOP(transit_system,stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,
-                    stop_street,stop_city,stop_region,stop_postcode,stop_country,zone_id,stop_url,location_type,
-                    parent_station,stop_timezone,wheelchair_boarding)
-                     VALUES(
-                     'METRO_TRANSIT', :stop_id, :stop_code, :stop_name, :stop_desc,
-                     :stop_lat, :stop_lon, :stop_street, :stop_city, :stop_region,
-                     :stop_postcode,:stop_country, :zone_id, :stop_url,
-                     :location_type, :parent_station, :stop_timezone, :wheelchair_boarding
-                    );
-                ]]>
-            </value>
-        </property>
-        <property name="itemSqlParameterSourceProvider">
-            <bean class="org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider"/>
-        </property>
-    </bean>
+    <import resource="../../main/stop-config.xml"/>
 
     <batch:job id="StopJob" restartable="false" job-repository="jobRepository">
         <batch:step id="step1">


### PR DESCRIPTION
I've moved the configuration used in test to src/main/resources. We want the tests to use (nearly) the same configuration as will be used in production. This minimizes the configuration that needs to be maintained.
